### PR TITLE
Fix parsing of attendee when common name is missing

### DIFF
--- a/PUCalendarKit/PUEventAttendee.m
+++ b/PUCalendarKit/PUEventAttendee.m
@@ -69,32 +69,28 @@
             
             //Scan attributes
             NSScanner *attributesScanner = [NSScanner scannerWithString:attributes];
-            NSString *placeholder = @"";
-            
+
+            NSString *role = @"";
             [attributesScanner scanUpToString:@"ROLE=" intoString:nil];
-            [attributesScanner scanUpToString:@";" intoString:&placeholder];
-            
-            NSString *role = [placeholder stringByReplacingOccurrencesOfString:@"ROLE=" withString:@""];
-            //Assign the Role
-            attendee.role = [role roleForICSRoleString];
+            [attributesScanner scanUpToString:@";" intoString:&role];
+            attendee.role = [[role stringByReplacingOccurrencesOfString:@"ROLE=" withString:@""] roleForICSRoleString];
 
+            NSString *status = @"";
             [attributesScanner scanUpToString:@"PARTSTAT=" intoString:nil];
-            [attributesScanner scanUpToString:@";" intoString:&placeholder];
+            [attributesScanner scanUpToString:@";" intoString:&status];
+            attendee.status = [status stringByReplacingOccurrencesOfString:@"PARTSTAT=" withString:@""];
 
-            NSString *status = [placeholder stringByReplacingOccurrencesOfString:@"PARTSTAT=" withString:@""];
-            attendee.status = status;
-            
+            NSString *name = @"";
             attributesScanner = [NSScanner scannerWithString:attributes];
             [attributesScanner scanUpToString:@"CN=" intoString:nil];
-            [attributesScanner scanUpToString:@";" intoString:&placeholder];
-            
-            NSString *name = [placeholder stringByReplacingOccurrencesOfString:@"CN=" withString:@""];
-            attendee.commonName = name;
+            [attributesScanner scanUpToString:@";" intoString:&name];
+            attendee.commonName = [name stringByReplacingOccurrencesOfString:@"CN=" withString:@""];;
 
+            NSString *email = @"";
             NSScanner *emailScanner = [NSScanner scannerWithString:attendeeString];
             [emailScanner scanUpToString:@"mailto:" intoString:nil];
-            [emailScanner scanUpToString:@"" intoString:&placeholder];
-            attendee.email = [placeholder stringByReplacingOccurrencesOfString:@"mailto:" withString:@"" options:NSCaseInsensitiveSearch range:NSMakeRange(0, [placeholder length])];
+            [emailScanner scanUpToString:@"" intoString:&email];
+            attendee.email = [email stringByReplacingOccurrencesOfString:@"mailto:" withString:@"" options:NSCaseInsensitiveSearch range:NSMakeRange(0, [email length])];
         }
         
         return attendee;


### PR DESCRIPTION
Parsing would be incorrect if the attendee had CN missing, e.g.:
```
ATTENDEE;CUTYPE=RESOURCE;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;X-NUM-GUEST
 S=0:mailto:superhuman.com_3633323632323332383537@resource.calendar.google.c
 om
```

vs when its not missing:
```
ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
 TRUE;CN=rahul@superhuman.com;X-NUM-GUESTS=0:mailto:rahul@superhuman.com
```

This was happening because we reuse the `placeholder` string to parse out different components. I think its cleaner and less error prone if we parse out each component in its own string.

Fixes https://github.com/superhuman/superhuman-ios/issues/2374